### PR TITLE
CORE-998: notification database migration utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+notification-migrator
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.14-alpine
+
+ENV CGO_ENABLED=0
+
+WORKDIR /go/src/github.com/cyverse-de/notification-migrator
+COPY . .
+RUN go build .
+
+FROM scratch
+
+WORKDIR /
+COPY --from=0 /go/src/github.com/cyverse-de/notification-migrator/notification-migrator /bin/notification-migrator
+
+ENTRYPOINT ["notification-migrator"]
+CMD ["--help"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/cyverse-de/notification-migrator
+
+go 1.14
+
+require (
+	github.com/DavidGamba/go-getoptions v0.19.0
+	github.com/Masterminds/squirrel v1.4.0
+	github.com/cyverse-de/dbutil v0.0.0-20170404194641-04e85e2737c9
+	github.com/lib/pq v1.5.2
+	github.com/pkg/errors v0.9.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/DavidGamba/go-getoptions v0.19.0 h1:HewLGtrPqhz72hTAmN6G/EBLPqhHugpCN5fpQcZ0Fjg=
+github.com/DavidGamba/go-getoptions v0.19.0/go.mod h1:wYjd1McJbGzBFD61+lahGR+5A8QGA1aBnRZmfkBLy5A=
+github.com/Masterminds/squirrel v1.4.0 h1:he5i/EXixZxrBUWcxzDYMiju9WZ3ld/l7QBNuo/eN3w=
+github.com/Masterminds/squirrel v1.4.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
+github.com/cyverse-de/dbutil v0.0.0-20170404194641-04e85e2737c9 h1:RdWfP04KnGOpFrtviAc3aRBCVU7h4Ch9oqZC6MudYzY=
+github.com/cyverse-de/dbutil v0.0.0-20170404194641-04e85e2737c9/go.mod h1:ExgEsAIPqEEtubF/XyUlj8+4ReFsbyT9QChN6EsorN8=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
+github.com/lib/pq v1.5.2 h1:yTSXVswvWUOQ3k1sd7vJfDrbSl8lKuscqFJRqjC0ifw=
+github.com/lib/pq v1.5.2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	"github.com/DavidGamba/go-getoptions"
+	"github.com/cyverse-de/dbutil"
+	"github.com/pkg/errors"
+
+	_ "github.com/lib/pq"
+)
+
+// commandLineOptionValues represents the option values that are accepted by this utility.
+type commandLineOptionValues struct {
+	Source string
+	Dest   string
+}
+
+// parseCommandLine parses the command-line and returns a structure containging the option
+// values specified on the command line. If the user requests help or a usage error is detected
+// then a usage message will be displayed and the program will exit.
+func parseCommandLine() *commandLineOptionValues {
+	optionValues := &commandLineOptionValues{}
+	opt := getoptions.New()
+
+	// Define the command-line options.
+	opt.Bool("help", false, opt.Alias("h", "?"))
+	opt.StringVar(&optionValues.Source, "source", "",
+		opt.Alias("s"),
+		opt.Required(),
+		opt.Description("the connection URI for the source database"))
+	opt.StringVar(&optionValues.Dest, "dest", "",
+		opt.Alias("d"),
+		opt.Required(),
+		opt.Description("the connection URI for the destination database"))
+
+	// Parse the command line, handling requests for help and usage errors.
+	_, err := opt.Parse(os.Args[1:])
+	if opt.Called("help") {
+		fmt.Fprintf(os.Stderr, opt.Help())
+		os.Exit(0)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n\n", err)
+		fmt.Fprintf(os.Stderr, opt.Help(getoptions.HelpSynopsis))
+	}
+
+	return optionValues
+}
+
+// initDatabase establishes a database connection and verifies that the database can be reached.
+func initDatabase(driverName, databaseURI string) (*sql.DB, error) {
+	wrapMsg := "unable to initialize the database"
+
+	// Create a database connector to establish the connection for us.
+	connector, err := dbutil.NewDefaultConnector("1m")
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+
+	// Establish the database connection.
+	db, err := connector.Connect(driverName, databaseURI)
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+
+	return db, nil
+}
+
+func main() {
+	// Parse the command-line optons.
+	optionValues := parseCommandLine()
+
+	// Establish the source database connection.
+	sourceDB, err := initDatabase("postgres", optionValues.Source)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "source database: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer sourceDB.Close()
+
+	// Establish the destination database connection.
+	destDB, err := initDatabase("postgres", optionValues.Dest)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "destination database: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer destDB.Close()
+
+	// Start a transaction for the source database to keep query results consistent.
+	sourceTx, err := sourceDB.Begin()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "source database: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer sourceTx.Rollback()
+
+	// Start a transaction for the destination database.
+	destTx, err := destDB.Begin()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "destination database: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer destTx.Rollback()
+
+	// Run the database migration.
+	err = runMigration(sourceTx, destTx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		os.Exit(1)
+	}
+
+	// Commit the transaction in the destination database.
+	err = destTx.Commit()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "destination database commit failed: %s\n", err.Error())
+		os.Exit(1)
+	}
+}

--- a/migration.go
+++ b/migration.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+// validateDestinationUsersTable verifies that the users table is empty in the destination database.
+func validateDestinationUsersTable(destTx *sql.Tx) error {
+	wrapMsg := "unable to verify that the destination users table is empty"
+
+	// Obtain and validate the number of users in the database.
+	row := destTx.QueryRow("SELECT count(*) FROM users")
+	var userCount int
+	err := row.Scan(&userCount)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+	if userCount > 0 {
+		return fmt.Errorf("the destination users table is not empty")
+	}
+
+	return nil
+}
+
+// migrateUsers migrates users to the destination database.
+func migrateUsers(sourceTx, destTx *sql.Tx) error {
+	wrapMsg := "user migration failed"
+
+	// Verify that the users table in the destination database is empty.
+	err := validateDestinationUsersTable(destTx)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Run the query to select the usernames from the source database.
+	sourceRows, err := sourceTx.Query("SELECT username FROM users")
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+	defer sourceRows.Close()
+
+	// Begin the insertion statement.
+	builder := sq.StatementBuilder.
+		PlaceholderFormat(sq.Dollar).
+		Insert("users").Columns("username")
+
+	// Add the values to the insertion statement.
+	for sourceRows.Next() {
+		var username string
+		err = sourceRows.Scan(&username)
+		if err != nil {
+			return errors.Wrap(err, wrapMsg)
+		}
+		builder = builder.Values(username)
+	}
+
+	// Generate the insertion statement and arguments.
+	statement, args, err := builder.ToSql()
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Execute the insert statement.
+	_, err = destTx.Exec(statement, args...)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	return nil
+}
+
+// validateDestinationNotifiationTypesTable verifies that the notification_types table in the
+// destination database is empty.
+func validateDestinationNotificationTypesTable(destTx *sql.Tx) error {
+	wrapMsg := "unable to validate the destination notification_types table"
+
+	// Obtain and validate the number of notification types in the database.
+	row := destTx.QueryRow("SELECT count(*) FROM notification_types")
+	var notificationTypeCount int
+	err := row.Scan(&notificationTypeCount)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+	if notificationTypeCount > 0 {
+		return fmt.Errorf("the destination notification_types table is not empty")
+	}
+
+	return nil
+}
+
+// migrateNotificationTypes migrates existing notification types to the destination database.
+func migrateNotificationTypes(sourceTx, destTx *sql.Tx) error {
+	wrapMsg := "notification type migration failed"
+
+	// Verify that the notification_types table in the destination database is empty.
+	err := validateDestinationNotificationTypesTable(destTx)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Query the source database for existing notification types.
+	sourceRows, err := sourceTx.Query("SELECT DISTINCT lower(type) FROM notifications")
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+	defer sourceRows.Close()
+
+	// Begin the insertion statement.
+	builder := sq.StatementBuilder.
+		PlaceholderFormat(sq.Dollar).
+		Insert("notification_types").Columns("name")
+
+	// Add each of the notification types to the insertion statement.
+	for sourceRows.Next() {
+		var notificationType string
+		err = sourceRows.Scan(&notificationType)
+		if err != nil {
+			return errors.Wrap(err, wrapMsg)
+		}
+		builder = builder.Values(notificationType)
+	}
+
+	// Generate the insertion statement and arguments.
+	statement, args, err := builder.ToSql()
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Execute the insert statement.
+	_, err = destTx.Exec(statement, args...)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	return nil
+}
+
+// validateDestinationNotificationsTable verifies that the notifications table in the
+// destination database is empty.
+func validateDestinationNotificationsTable(destTx *sql.Tx) error {
+	wrapMsg := "unable to validate the destination notifications table"
+
+	// Obtain and validate the number of notifications in the database.
+	row := destTx.QueryRow("SELECT count(*) FROM notifications")
+	var notificationCount int
+	err := row.Scan(&notificationCount)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+	if notificationCount > 0 {
+		return fmt.Errorf("the destination notifictions table is not empty")
+	}
+
+	return nil
+}
+
+// getNotificationTypeIDMap returns a map from notification type name to ID.
+func getNotificationTypeIDMap(destTx *sql.Tx) (map[string]string, error) {
+	wrapMsg := "unable to load the notification type ID map"
+
+	// Execute the query.
+	rows, err := destTx.Query("SELECT id, name FROM notification_types")
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+	defer rows.Close()
+
+	// Build the map.
+	result := make(map[string]string)
+	for rows.Next() {
+		var id, name string
+		err = rows.Scan(&id, &name)
+		if err != nil {
+			return nil, errors.Wrap(err, wrapMsg)
+		}
+		result[name] = id
+	}
+
+	return result, nil
+}
+
+// getUserIDMap returns a map from username to internal user ID.
+func getUserIDMap(destTx *sql.Tx) (map[string]string, error) {
+	wrapMsg := "unable to laod the user ID map"
+
+	// Execute the query.
+	rows, err := destTx.Query("SELECT id, username FROM users")
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+	defer rows.Close()
+
+	// Build the map.
+	result := make(map[string]string)
+	for rows.Next() {
+		var id, username string
+		err = rows.Scan(&id, &username)
+		if err != nil {
+			return nil, errors.Wrap(err, wrapMsg)
+		}
+		result[username] = id
+	}
+
+	return result, nil
+}
+
+// migrateNotifications migrates existing notifications to the destination database.
+func migrateNotifications(sourceTx, destTx *sql.Tx) error {
+	wrapMsg := "notification migration failed"
+
+	// Verify that the destination notifications table is empty.
+	err := validateDestinationNotificationsTable(destTx)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Obtain a map from notification type name to ID.
+	notificationTypeIDFor, err := getNotificationTypeIDMap(destTx)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Obtain a map from user name to ID.
+	userIDFor, err := getUserIDMap(destTx)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Run the query to retrieve the notifications from the source database.
+	sourceQuery := `
+		SELECT n.uuid,
+			   lower(n.type),
+			   u.username,
+			   n.subject,
+			   n.seen,
+			   n.deleted,
+			   n.date_created,
+			   n.message
+		FROM notifications n
+		JOIN users u ON n.user_id = u.id
+		ORDER BY n.date_created
+	`
+	sourceRows, err := sourceTx.Query(sourceQuery)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+	defer sourceRows.Close()
+
+	// Begin the insertion statement.
+	base := sq.StatementBuilder.
+		PlaceholderFormat(sq.Dollar).
+		Insert("notifications").
+		Columns("id", "notification_type_id", "user_id", "subject", "seen", "deleted", "time_created", "message")
+
+	// insert each notification into the destination database. This is done one at a time to avoid argument limits.
+	for sourceRows.Next() {
+		var id, notificationType, username, subject, seen, deleted, timeCreated, message string
+
+		// Retrieve the values for the current notification.
+		err := sourceRows.Scan(&id, &notificationType, &username, &subject, &seen, &deleted, &timeCreated, &message)
+		if err != nil {
+			return errors.Wrap(err, wrapMsg)
+		}
+		notificationTypeID := notificationTypeIDFor[notificationType]
+		userID := userIDFor[username]
+
+		// Generate the insertion statement and arguments for this notification.
+		builder := base.Values(id, notificationTypeID, userID, subject, seen, deleted, timeCreated, message)
+		query, args, err := builder.ToSql()
+		if err != nil {
+			return errors.Wrap(err, wrapMsg)
+		}
+
+		// Execute the statement.
+		_, err = destTx.Exec(query, args...)
+		if err != nil {
+			return errors.Wrap(err, wrapMsg)
+		}
+	}
+
+	return nil
+}
+
+// runMigration performs the actual database migration.
+func runMigration(sourceTx, destTx *sql.Tx) error {
+	wrapMsg := "database migration failed"
+
+	// Migrate the users from the source database to the destination database.
+	err := migrateUsers(sourceTx, destTx)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Migrate the notification types from the source database to the destnation database.
+	err = migrateNotificationTypes(sourceTx, destTx)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	// Migrate the notifications from the source database to the destination database.
+	err = migrateNotifications(sourceTx, destTx)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+
+	return nil
+}


### PR DESCRIPTION
My next task is to create the Jenkinsfile. As usual, the easiest way to iterate on the Jenkinsfile is to push changes directly to master and keep an eye in Jenkins to see what breaks. At least that's the easiest way that I've found. For this reason, I'm hoping to get a review on this utility today and work on the Jenkinsfile sometime in the next few days.

This utility is pretty simple. The file, `main.go`, contains the code to parse the command line and establish the database connections. The file, `migration.go`, contains the code to actually migrate the data to the new notification database. The migration executes simple SQL statements and allows the database driver to manage the type conversions.

In most cases, the migration inserts the data into the destination database using a single `INSERT` statement. The one exception is the notifications themselves, which can't be done in one statement because we're running into Postgres's limit for the number of arguments. I briefly considered updating the code for the `users` table so that it executes individual `INSERT` statements as well, but ultimately decided against it. The probability that an external DE deployment will run into this limit for users is smaller than the probability that our DE deployment will, and our deployment isn't close to encountering it yet.